### PR TITLE
Change deprecated class names

### DIFF
--- a/custom_components/domintell/binary_sensor.py
+++ b/custom_components/domintell/binary_sensor.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import CONF_NAME, CONF_DEVICES
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 
@@ -58,7 +58,7 @@ def create_sensor(sensor, domintell):
         module_type = sensor['type']
         return DomintellBinarySensor(sensor, domintell)
 
-class DomintellBinarySensor(BinarySensorDevice):
+class DomintellBinarySensor(BinarySensorEntity):
     """Representation of a Domintell Binary sensor."""
 
     def __init__(self, sensor, domintell):

--- a/custom_components/domintell/light.py
+++ b/custom_components/domintell/light.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 # Import the device class from the component that you want to support
-from homeassistant.components.light import ATTR_BRIGHTNESS, Light, LightEntity, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS
+from homeassistant.components.light import ATTR_BRIGHTNESS, LightEntity, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 


### PR DESCRIPTION
With the update to 2022.x there are soms errors from class names that are changed. 

Light -> LightEntity 
this was already ok i just deleted the old Light classname

BinarySensorDevice -> BinarySensorEntity
I updated this classname BinarySensorDevice  to BinarySensorEntity where needed